### PR TITLE
fix: properly parse weekly collection index files

### DIFF
--- a/adsdocmatch/match_w_metadata.py
+++ b/adsdocmatch/match_w_metadata.py
@@ -42,6 +42,31 @@ class MatchMetadata():
             logger.error('Unable to open/read input file', e)
         return filenames
 
+    def get_ads_record_filenames(self, filename):
+        """
+        read the list of new records in (classic) collection index,
+        and generate a list of files with appropriate paths and extensions
+        :param filename:
+        :return:
+        """
+        filenames = []
+        try:
+            collection_dirlist = os.path.dirname(filename).split('/')
+            collection_index = collection_dirlist.index('index')
+            collection_text_basepath = "/".join(collection_dirlist[0:collection_index])
+            with open(filename, 'r') as fp:
+                for l in fp.readlines():
+                    file_accno = l.strip('\r\n').split('\t')[1]
+                    accno_prefix = file_accno.split('-')[0]
+                    new_path = os.path.join(collection_text_basepath,
+                                            "text",
+                                            accno_prefix)
+                    new_filename = new_path + "/" + file_accno + ".abs"
+                    filenames.append(os.path.normpath(new_filename))
+        except Exception as err:
+            logger.error('Unable to process collection index list (%s): %s' % (filename, err))
+        return filenames
+
     def process_results(self, results, separator):
         """
 
@@ -128,7 +153,7 @@ class MatchMetadata():
         :param result_filename: name of result file to write to
         :return:
         """
-        filenames = self.get_input_filenames(input_filename)
+        filenames = self.get_ads_record_filenames(input_filename)
         if len(filenames) > 0:
             if result_filename:
                 # one file at a time, parse and score, and then write the result to the file

--- a/adsdocmatch/tests/unittests/test_docmatch.py
+++ b/adsdocmatch/tests/unittests/test_docmatch.py
@@ -222,7 +222,6 @@ class TestDocMatch(unittest.TestCase):
         input_filename = "%s%s%s" % (path, current_dir, config['DOCMATCHPIPELINE_INPUT_FILENAME'])
         result_filename = "%s%s%s" % (path, current_dir, config['DOCMATCHPIPELINE_EPRINT_RESULT_FILENAME'])
 
-        print('lolwut i/o: %s /// %s' % (input_filename, result_filename))
         # create input file with list of pub filenames
         eprint_filenames = ['/K47-02665.abs']
         mocked_eprint_filenames = []
@@ -232,7 +231,6 @@ class TestDocMatch(unittest.TestCase):
                 mocked_eprint_filenames.append("%s" % (path+current_dir+filename))
             f.close()
 
-        print('i made it here... "create output file"')
         # create output file
         return_value = [{
             'source_bibcode': '2018ApJS..236...24F',
@@ -248,7 +246,6 @@ class TestDocMatch(unittest.TestCase):
             'source bibcode (link),verified bibcode,matched bibcode (link),label,confidence,matched scores,comment',
             '"=HYPERLINK(""https://ui.adsabs.harvard.edu/abs/2018ApJS..236...24F/abstract"",""2018ApJS..236...24F"")",,"=HYPERLINK(""https://ui.adsabs.harvard.edu/abs/.................../abstract"",""..................."")",Not Match,0,"","No matches with DOI [\'10.3847/1538-4365/aab760\'] in pubnote, trying Abstract. No result from solr with Abstract, trying Title. No result from solr with Title. No document was found in solr matching the request."',
         ]
-        print('i made it here "make sure output file is written properly"')
 
         # make sure output file is written properly
         with open(result_filename, "r") as f:

--- a/run.py
+++ b/run.py
@@ -108,7 +108,7 @@ def main():
                         outFile = MatchMetadata().process_match_to_pub(path)
                         filesToUpload.append(outFile)
                     if args.match_to_eprint:
-                        fileList = MatchMetadata().process_match_to_arXiv(path)
+                        outFile = MatchMetadata().process_match_to_arXiv(path)
                         filesToUpload.append(outFile)
                     # If either process created files to upload,
                     # send them to the Google Drive now.


### PR DESCRIPTION
Input files from weekly collection indexes consist of two-column, tab-separated lines consisting of the bibcode, and the record's accession number.  The full pathname linking to the text file for the accession number can be generated from the path of the input file, which is .../abstracts/[collection]/index/["current" or "done.YYYY-MM-DD"]/ and the 3-character prefix of the accession number: .../abstracts/[collection]/text/[prefix]/accno.abs